### PR TITLE
Added missing rpc methods and update "getInfo" method for deprecation

### DIFF
--- a/lib/config/constant.js
+++ b/lib/config/constant.js
@@ -32,14 +32,7 @@ module.exports = {
     },
     transaction: {
       method: {
-        send: 'gallactic.send',
-        sendNHold: 'gallactic.sendAndHold',
-        transact: 'gallactic.transact',
-        transactNHold: 'gallactic.transactAndHold',
-        transactNameReg: 'gallactic.transactNameReg',
-        broadcastTxn: 'gallactic.broadcastTx',
-        call: 'gallactic.call',
-        callCode: 'gallactic.callCode'
+        broadcastTxn: 'gallactic.broadcastTx'
       }
     }
   },

--- a/lib/config/constant.js
+++ b/lib/config/constant.js
@@ -11,7 +11,8 @@ module.exports = {
         getAccount: 'gallactic.getAccount',
         getStorage: 'gallactic.getStorage',
         getStorageAt: 'gallactic.getStorageAt',
-        getValidator: 'gallactic.getValidator'
+        getValidator: 'gallactic.getValidator',
+        getValidators: 'gallactic.getValidators'
       }
     },
     blockchain: {

--- a/lib/config/constant.js
+++ b/lib/config/constant.js
@@ -10,7 +10,8 @@ module.exports = {
         getAccounts: 'gallactic.getAccounts',
         getAccount: 'gallactic.getAccount',
         getStorage: 'gallactic.getStorage',
-        getStorageAt: 'gallactic.getStorageAt'
+        getStorageAt: 'gallactic.getStorageAt',
+        getValidator: 'gallactic.getValidator'
       }
     },
     blockchain: {

--- a/lib/config/constant.js
+++ b/lib/config/constant.js
@@ -19,12 +19,15 @@ module.exports = {
       method: {
         getBcInfo: 'gallactic.getBlockChainInfo',
         getChainId: 'gallactic.getChainId',
-        getGenesisHash: 'gallactic.getGenesisHash',
-        getLatestBlockHeight: 'gallactic.getLatestBlockHeight',
         getLatestBlock: 'gallactic.getLatestBlock',
         getBlocks: 'gallactic.getBlocks',
         getBlock: 'gallactic.getBlock',
-        getBlockTxns: 'gallactic.getBlockTxs'
+        getBlockTxns: 'gallactic.getBlockTxs',
+        getConsensusState: 'gallactic.getConsensusState',
+        getGenesis: 'gallactic.getGenesis',
+        getPeers: 'gallactic.getPeers',
+        getStatus: 'gallactic.getStatus',
+        getUnconfirmedTxs: 'gallactic.getUnconfirmedTxs'
       }
     },
     transaction: {

--- a/lib/intergallactic/account.js
+++ b/lib/intergallactic/account.js
@@ -73,7 +73,7 @@ class Account {
     return this.conn.send(req);
   }
   /**
-   * To get validator account information
+   * To get a specific validator account information
    * @param {String} address [A hex string 20 characters long or 40 bytes]
    * @returns {Object} [An object contains the account details of an address]
    */
@@ -83,6 +83,18 @@ class Account {
       params: {
         address: address
       }
+    };
+    return this.conn.send(req)
+  }
+  /**
+   * To get list of validator account information
+   * @param {String} address [A hex string 20 characters long or 40 bytes]
+   * @returns {Object} [An object contains the account details of an address]
+   */
+  listValidators(address) {
+    let req = {
+      bcMethod: accountMtd.getValidators,
+      params: {}
     };
     return this.conn.send(req)
   }

--- a/lib/intergallactic/account.js
+++ b/lib/intergallactic/account.js
@@ -72,6 +72,20 @@ class Account {
     };
     return this.conn.send(req);
   }
+  /**
+   * To get validator account information
+   * @param {String} address [A hex string 20 characters long or 40 bytes]
+   * @returns {Object} [An object contains the account details of an address]
+   */
+  getValidator(address) {
+    let req = {
+      bcMethod: accountMtd.getValidator,
+      params: {
+        address: address
+      }
+    };
+    return this.conn.send(req)
+  }
 }
 
 module.exports = Account;

--- a/lib/intergallactic/gallactic.js
+++ b/lib/intergallactic/gallactic.js
@@ -37,8 +37,9 @@ class Gallactic {
    * @returns {Object} Promise contains the node info e.g. latest block, version and etc
    */
   getInfo() {
+    console.warn('"getInfo" method is going to be deprecated! use "getStatus" method instead');
     let req = {
-      bcMethod: bcMtd.getBcInfo,
+      bcMethod: bcMtd.getStatus,
       params: {}
     };
     return this.conn.send(req);

--- a/lib/intergallactic/gallactic.js
+++ b/lib/intergallactic/gallactic.js
@@ -82,6 +82,66 @@ class Gallactic {
     };
     return this.conn.send(req)
   }
+
+  /**
+   * Get consensus state information
+   * @returns {Object} Promise contains consensus state information
+   */
+  getConsensusState() {
+    let req = {
+      bcMethod: bcMtd.getConsensusState,
+      params: {}
+    };
+    return this.conn.send(req)
+  }
+
+  /**
+   * Get genesis json information
+   * @returns {Object} Promise contains genesis json information
+   */
+  getGenesis() {
+    let req = {
+      bcMethod: bcMtd.getGenesis,
+      params: {}
+    };
+    return this.conn.send(req)
+  }
+
+  /**
+   * Get node's peers information
+   * @returns {Object} Promise contains node's peers information
+   */
+  getPeers() {
+    let req = {
+      bcMethod: bcMtd.getPeers,
+      params: {}
+    };
+    return this.conn.send(req)
+  }
+
+  /**
+   * Get Bc node status along with some information
+   * @returns {Object} Promise contains the node info e.g. latest block, version and etc
+   */
+  getStatus() {
+    let req = {
+      bcMethod: bcMtd.getStatus,
+      params: {}
+    };
+    return this.conn.send(req);
+  }
+
+  /**
+   * Get node status along with some information
+   * @returns {Object} Promise contains the node info e.g. latest block, version and etc
+   */
+  getUnconfirmedTxs() {
+    let req = {
+      bcMethod: bcMtd.getUnconfirmedTxs,
+      params: {}
+    };
+    return this.conn.send(req);
+  }
 }
 
 module.exports = Gallactic

--- a/lib/intergallactic/transaction.js
+++ b/lib/intergallactic/transaction.js
@@ -22,13 +22,15 @@ const config = require('../config/constant'),
  * const privKey = '<insert_private_key>'
  * const igc = new Intergallactic({ url: 'localhost:1337/rpc', protocol: 'jsonrpc' });
  * const txn = {
- *   senders: [{
- *   address: testAcc.address,
- *     amount: 10
+ *   from: [{
+ *     address: testAcc.address,
+ *     amount: 10,
+ *     unit: 'boson'
  *   }],
- *   receivers: [{
+ *   to: [{
  *     address: 'acWmVcNrHzxBF8L25vdiKLsz664ZGkYmPRj',
  *     amount: 10
+ *     unit: 'boson'
  *   }]
  * };
  * const opt = { txnType: 1 // required }
@@ -73,11 +75,20 @@ class Transaction {
    * @returns {String} a Promise that contains the transaction signature string
    */
   sign(privKey) {
-    const address = gkeys.utils.crypto.getAcAddrByPrivKey(privKey);
+    // signing transaction require account address
+    // except signing for unbond txn, it requires validator address
+    const address = this.txnType === UBND_TXN_TYPE
+      ? gkeys.utils.crypto.getVaAddrByPrivKey(privKey)
+      : gkeys.utils.crypto.getAcAddrByPrivKey(privKey);
     const getChainIdNSequence = () => {
+      const getAccount = () => {
+        return gkeys.utils.crypto.isVaAddress(address)
+          ? this.igc.account.getValidator(address)
+          : this.igc.account.getAccount(address)
+      }
       return Promise.all([
         this.igc.gallactic.getChainId(),
-        this.igc.account.getAccount(address)
+        getAccount(address)
       ]);
     }
     const buildTxn = res => {
@@ -87,8 +98,10 @@ class Transaction {
       if (!this.chainId && chainRes && chainRes.body && chainRes.body.result) {
         this.chainId = chainRes.body.result.ChainId;
       }
-      if (!this.sequence && accRes && accRes.body && accRes.body.result && accRes.body.result.Account) {
-        this.sequence = accRes.body.result.Account.sequence;
+
+      if (!this.sequence && accRes && accRes.body && accRes.body.result
+        && (accRes.body.result.Account || accRes.body.result.Validator)) {
+        this.sequence = (accRes.body.result.Account || accRes.body.result.Validator).sequence;
       }
       if (!this.chainId) {
         throw new Error('Unable to retrieve Chain Id, please try again later');
@@ -147,7 +160,10 @@ class Transaction {
   signNBroadcast (privKey) {
     let pubKey, signatories;
 
-    pubKey = gkeys.utils.crypto.getPubKeyByPrivKey(privKey);
+    // get the tm pub key
+    pubKey = gkeys.utils.crypto.getTmPubKeyByPrivKey(privKey);
+    // base58 encode the pubkey
+    pubKey = gkeys.utils.crypto.bs58Encode(pubKey, 4) // TODO: replace 4 with gkeys.constant._PUB_KEY_ID
     return this.sequence && this.chainId ? this.signSync(privKey) : this.sign(privKey)
       .then(signature => {
         signatories = [{ publicKey: pubKey, signature }]
@@ -188,6 +204,11 @@ class Transaction {
     return this.broadcast();
   }
 
+  /**
+   * To broadcast "BOND transaction" to the blockchain node
+   * @param {Array} signatories an array of object that contains public key and txn signature
+   * @returns {Object} a Promise that contains the transaction info
+   */
   bond(signatories) {
     validateSignatories(signatories);
     validateTxnType(this.txnType, BOND_TXN_TYPE);
@@ -197,6 +218,11 @@ class Transaction {
     return this.broadcast();
   }
 
+  /**
+   * To broadcast "UNBOND transaction" to the blockchain node
+   * @param {Array} signatories an array of object that contains public key and txn signature
+   * @returns {Object} a Promise that contains the transaction info
+   */
   unbond(signatories) {
     validateSignatories(signatories);
     validateTxnType(this.txnType, UBND_TXN_TYPE);
@@ -206,6 +232,11 @@ class Transaction {
     return this.broadcast();
   }
 
+  /**
+   * To broadcast "PERMISSION transaction" to the blockchain node
+   * @param {Array} signatories an array of object that contains public key and txn signature
+   * @returns {Object} a Promise that contains the transaction info
+   */
   permission(signatories) {
     validateSignatories(signatories);
     validateTxnType(this.txnType, PERM_TXN_TYPE);
@@ -237,8 +268,12 @@ function signByPrivKey (privKey, txn, txnType, chainId) {
   });
 
   let data = {
-    privKey: gkeys.utils.util.strToBuffer(privKey, 'hex'),
-    message: gkeys.utils.util.strToBuffer(signObj)
+    // base 58 decode the private key and convert it to buffer
+    privKey: gkeys.utils.util.strToBuffer(
+      gkeys.utils.crypto.bs58Decode(privKey), 'hex'
+    ),
+    // message need to be keccak hashed before converted to buffer
+    message: gkeys.utils.util.strToBuffer(gkeys.utils.crypto.sha3(signObj))
   };
 
   return gkeys.utils.util.bytesToHexUpperString(

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bignumber.js": "7.2.1",
-    "gallactickeys": "^0.2.1",
+    "gallactickeys": "^0.2.2",
     "node-fetch": "2.1.2"
   },
   "repository": {

--- a/test/intergallactic/account.test.js
+++ b/test/intergallactic/account.test.js
@@ -27,10 +27,10 @@ describe('igc.account', function () {
     expect(igc.account.getStorageAt).to.be.a('function');
   });
 
-  it('"listAccounts", should return account details', function (done) {
+  it('"listAccounts", should return list of account details', function (done) {
     const test = {
       function: (data) => {
-        return igc.account.listAccounts(data.address)
+        return igc.account.listAccounts()
       },
       validate: function (res) {
         expect(res.body).to.be.an('object');
@@ -61,24 +61,70 @@ describe('igc.account', function () {
 
     test.data = [{
       input: {
-        address: 'acFbhUU8JK8mPhwYqMwy1DRrKP8fwUwnQMY'
+        address: 'acFVrNat8Y8Evid4fcJzN5KxyEAyuHS6Tuu'
       },
       validate: (res) => {
-        expect(res.body.result.Account.address).to.equal('acFbhUU8JK8mPhwYqMwy1DRrKP8fwUwnQMY');
+        expect(res.body.result.Account.address).to.equal('acFVrNat8Y8Evid4fcJzN5KxyEAyuHS6Tuu');
       }
     }, {
       input: {
-        address: 'acLmQjWRZ4XmNZ7QfydbymbKKDYRSunkTua'
+        address: 'acT1MVKCaTVKhBwpMr667vA9VRtubFtiwZf'
       },
       validate: (res) => {
-        expect(res.body.result.Account.address).to.equal('acLmQjWRZ4XmNZ7QfydbymbKKDYRSunkTua');
+        expect(res.body.result.Account.address).to.equal('acT1MVKCaTVKhBwpMr667vA9VRtubFtiwZf');
       }
     }],
 
     glOrWd.runTest(test, done);
   });
 
-  it('"getStorage", should return storage details', function (done) {
+  it('"listValidators", should return list of validator account details', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.account.listValidators()
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.result).to.be.an('object');
+        expect(res.body.result.BondedValidators).to.be.an('array');
+        expect(res.body.result.UnbondingValidators).to.not.equal(undefined);
+      }
+    };
+
+    test.data = [{
+      input: {}
+    }];
+
+    glOrWd.runTest(test, done);
+  })
+
+  it('"getValidator", should return validator account details', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.account.getValidator(data.address);
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.result).to.be.an('object');
+        expect(res.body.result.Validator).to.be.an('object');
+      }
+    };
+
+    test.data = [{
+      input: {
+        address: 'vaBdTQnKWstzbP9rrMCvPP4rxqLU3PDvKHM'
+      },
+      validate: (res) => {
+        expect(res.body.result.Validator.publicKey).to.be.a('string');
+      }
+    }];
+
+    glOrWd.runTest(test, done);
+  })
+
+  it.skip('"getStorage", should return storage details', function (done) {
     const test = {
       function: (data) => {
         return igc.account.getStorage(data.address);
@@ -93,14 +139,14 @@ describe('igc.account', function () {
     };
     test.data = [{
       input: {
-        address: 'acLmQjWRZ4XmNZ7QfydbymbKKDYRSunkTua'
+        address: 'acHcDPZqkYYDsVFAypgX77xuZDNqQDbynpP'
       }
     }]
 
     glOrWd.runTest(test, done);
   });
 
-  it('"getStorageAt", should return storage details', function (done) {
+  it.skip('"getStorageAt", should return storage details', function (done) {
     const test = {
       function: (data) => {
         return igc.account.getStorageAt(data.address, data.key);
@@ -114,7 +160,7 @@ describe('igc.account', function () {
     };
     test.data = [{
       input: {
-        address: 'acLmQjWRZ4XmNZ7QfydbymbKKDYRSunkTua',
+        address: 'acG9u2dcdu1kZoSEyxuGU7aWv3sHA8KNebo',
         key: 'greeting'
       }
     }]

--- a/test/intergallactic/gallactic.test.js
+++ b/test/intergallactic/gallactic.test.js
@@ -61,12 +61,12 @@ describe('Intergallactic.gallactic', function () {
         expect(res.statusCode).to.equal(200);
         expect(res).to.be.an('object');
         expect(res.body.result).to.be.an('object');
-        expect(res.body.result.result).to.be.an('object');
-        expect(res.body.result.result.node_info).to.be.an('object');
-        expect(res.body.result.result.latest_block_hash).to.be.a('string');
-        expect(res.body.result.result.latest_app_hash).to.be.a('string');
-        expect(res.body.result.result.latest_block_height).to.be.a('number');
-        expect(res.body.result.result.latest_block_time).to.be.a('string');
+        expect(res.body.result.NodeInfo).to.be.an('object');
+        expect(res.body.result.PubKey).to.be.a('string');
+        expect(res.body.result.GenesisHash).to.be.a('string');
+        expect(res.body.result.LatestBlockHash).to.be.a('string');
+        expect(res.body.result.LatestBlockHeight).to.be.a('number');
+        expect(res.body.result.LatestBlockTime).to.be.a('number');
         expect(res.body.result.NodeVersion).to.be.a('string');
       }
     }

--- a/test/intergallactic/gallactic.test.js
+++ b/test/intergallactic/gallactic.test.js
@@ -148,6 +148,8 @@ describe('Intergallactic.gallactic', function () {
         expect(res.statusCode).to.equal(200);
         expect(res).to.be.an('object');
         expect(res.body.result).to.be.an('object');
+        expect(res.body.result.Count).to.be.an('number');
+        expect(res.body.result.Txs).to.be.an('array');
         // expect(res.body.result.ResultBlock).to.be.an('object');
         // expect(res.body.result.ResultBlock.block_meta.header.height)
         //   .to.equal(input.height);
@@ -159,6 +161,117 @@ describe('Intergallactic.gallactic', function () {
         height: 5
       }
     }]
+
+    glOrWd.runTest(test, done);
+  });
+
+  it('"getConsensusState", should return the Consensus state infor', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.gallactic.getConsensusState();
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.result.RoundState).to.be.an('object');
+        expect(res.body.result.RoundState['height/round/step']).to.be.a('string');
+        expect(res.body.result.RoundState.height_vote_set).to.be.a('array');
+        expect(res.body.result.PeerRoundStates).to.be.an('array');
+      }
+    };
+
+    test.data = [{
+      input: {}
+    }];
+
+    glOrWd.runTest(test, done);
+  })
+
+  it('"getGenesis", should return genesis json information', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.gallactic.getGenesis();
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.result).to.be.an('object');
+        expect(res.body.result.Genesis).to.be.an('object');
+        expect(res.body.result.Genesis.chainName).to.be.a('string');
+        expect(res.body.result.Genesis.genesisTime).to.be.a('string');
+        expect(res.body.result.Genesis.maximumPower).to.be.a('number');
+        expect(res.body.result.Genesis.sortitionFee).to.be.a('number');
+        expect(res.body.result.Genesis.global).to.be.an('object');
+        expect(res.body.result.Genesis.accounts).to.be.an('array');
+        expect(res.body.result.Genesis.contracts).to.be.an('array');
+        expect(res.body.result.Genesis.validators).to.be.an('array');
+      }
+    }
+
+    test.data = [{
+      input: {}
+    }];
+
+    glOrWd.runTest(test, done);
+  });
+
+  it('"getPeers", should return node\'s peers information', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.gallactic.getPeers();
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+      }
+    }
+
+    test.data = [{
+      input: {}
+    }];
+
+    glOrWd.runTest(test, done);
+  });
+
+  it('"getStatus", should return blockchain status and other info', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.gallactic.getStatus();
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res).to.be.an('object');
+        expect(res.body.result).to.be.an('object');
+        expect(res.body.result.NodeInfo).to.be.an('object');
+        expect(res.body.result.PubKey).to.be.a('string');
+        expect(res.body.result.GenesisHash).to.be.a('string');
+        expect(res.body.result.LatestBlockHash).to.be.a('string');
+        expect(res.body.result.LatestBlockHeight).to.be.a('number');
+        expect(res.body.result.LatestBlockTime).to.be.a('number');
+        expect(res.body.result.NodeVersion).to.be.a('string');
+      }
+    }
+
+    test.data = [{
+      input: {}
+    }]
+
+    glOrWd.runTest(test, done);
+  });
+
+  it('"getUnconfirmedTxs", should return list of unconfirmed transaction info', function (done) {
+    const test = {
+      function: (data) => {
+        return igc.gallactic.getUnconfirmedTxs();
+      },
+      validate: (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.result).to.be.an('object');
+        expect(res.body.result.Count).to.be.a('number');
+        expect(res.body.result.Txs).to.not.equal(undefined);
+      }
+    };
+
+    test.data = [{
+      input: {}
+    }];
 
     glOrWd.runTest(test, done);
   });

--- a/test/intergallactic/transaction.test.js
+++ b/test/intergallactic/transaction.test.js
@@ -9,7 +9,7 @@ const testAcc = {
   privKey: 'ski47BSAmY6PJ9KMHXHMzk7tG8nXTJaKKF2BTRPzmjJ3NAzy1HxMAz336JiN7N8KzF786T2mptHHbBY5fmFeoaNukokkF66',
   pubKey: 'pkCogxsiXdTj9yn62cXN6L5NHwcrBfS8N2bYhob4HTPDExJfWpD'
 }
-before('instantiate IGC', function () {
+before('instantiate Intergallactic', function () {
   new Intergallactic({ url: glOrWd.tnet, protocol: 'jsonrpc' });
 });
 
@@ -64,7 +64,7 @@ describe('Intergallactic.Transaction', function () {
         privKey: testAcc.privKey,
         opt: {
           type: 1,
-          chainId: 'Gallactica-Chain88291',
+          chainId: 'test-chain-5bc7',
           sequence: 300
         },
         txn: {
@@ -84,7 +84,7 @@ describe('Intergallactic.Transaction', function () {
         privKey: testAcc.privKey,
         opt: {
           type: 2,
-          chainId: 'Gallactica-Chain88291',
+          chainId: 'test-chain-5bc7',
           sequence: 300
         },
         txn: {

--- a/test/intergallactic/transaction.test.js
+++ b/test/intergallactic/transaction.test.js
@@ -5,9 +5,9 @@ var Intergallactic = glOrWd.Intergallactic;
 var expect = glOrWd.expect;
 
 const testAcc = {
-  address: 'acFbhUU8JK8mPhwYqMwy1DRrKP8fwUwnQMY',
-  privKey: 'B3F4AE2C242ACEE2374C49990DD196361A88B25EDA473947A381830B3B4D418F2D47D0F43B27C57815E3317624742468D929544DF142ABA49AFFD9E00C8B1FCF',
-  pubKey: '2D47D0F43B27C57815E3317624742468D929544DF142ABA49AFFD9E00C8B1FCF'
+  address: 'acFVrNat8Y8Evid4fcJzN5KxyEAyuHS6Tuu',
+  privKey: 'ski47BSAmY6PJ9KMHXHMzk7tG8nXTJaKKF2BTRPzmjJ3NAzy1HxMAz336JiN7N8KzF786T2mptHHbBY5fmFeoaNukokkF66',
+  pubKey: 'pkCogxsiXdTj9yn62cXN6L5NHwcrBfS8N2bYhob4HTPDExJfWpD'
 }
 before('instantiate IGC', function () {
   new Intergallactic({ url: glOrWd.tnet, protocol: 'jsonrpc' });
@@ -230,10 +230,10 @@ describe('Intergallactic.Transaction', function () {
     }]
 
     this.timeout(10000);
-    setTimeout(function () { glOrWd.runTest(test, done) }, 5000);
+    setTimeout(function () { glOrWd.runTest(test, done) }, 0);
   });
 
-  it('"call", should call the given transaction', function (done) {
+  it.skip('"call", should call the given transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
@@ -275,10 +275,10 @@ describe('Intergallactic.Transaction', function () {
       }
     }];
     this.timeout(10000);
-    setTimeout(function () { glOrWd.runTest(test, done) }, 5000);
+    setTimeout(function () { glOrWd.runTest(test, done) }, 2000);
   });
 
-  it.skip('"bond", should bond the given transaction', function (done) {
+  it('"bond", should bond the given transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
@@ -311,11 +311,11 @@ describe('Intergallactic.Transaction', function () {
             unit: 'boson'
           },
           to: {
-            address: 'vaUjHHvCLmUzbzrz7xgF266xZEDvRa6RSDC',
+            address: 'vaBdTQnKWstzbP9rrMCvPP4rxqLU3PDvKHM',
             amount: 100,
             unit: 'boson'
           },
-          publicKey: 'd67a7f69cfecfbacfa45046942191b310dc4ff1f9e8bf71de565949fc72af373'
+          publicKey: 'pjDvQc1rF8HhCAK8L8zu3SJQcKtCMroo1rmRWf8o8m111DexqzX'
         }
       },
       validate: () => {
@@ -324,10 +324,10 @@ describe('Intergallactic.Transaction', function () {
     }];
 
     this.timeout(5000);
-    setTimeout(function () { glOrWd.runTest(test, done); }, 5000);
+    setTimeout(function () { glOrWd.runTest(test, done); }, 2000);
   });
 
-  it.skip('"unbond", should unbond the given transaction', function (done) {
+  it('"unbond", should unbond the given transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
@@ -352,13 +352,13 @@ describe('Intergallactic.Transaction', function () {
       input: {
         // privKey: testAcc.privKey,
         // pubKey: testAcc.pubKey,
-        privKey: '0A0766C934FAFE80E73A088B25406291AA6959B34446D82D2DD698C88100EDD9BD9E00FA32C8D1826EA4436F3817F800D201E0756A14735C4D2F72F30D11B1BE',
-        pubKey: 'BD9E00FA32C8D1826EA4436F3817F800D201E0756A14735C4D2F72F30D11B1BE',
+        privKey: 'skWKMJw3ohL81ACUNFMEzVcfa9GrWyVyQC33FUeRNLSa1MMHshZVgLuxQQPCB8AyCfxZQh98HuLfvqG5zqtVawdnP237bpn',
+        pubKey: 'pjDvQc1rF8HhCAK8L8zu3SJQcKtCMroo1rmRWf8o8m111DexqzX',
         txnType: 4,
         txn: {
           from: {
             // address: testAcc.address
-            address: 'vaSe5zgueCAdo4VRKf9wtMnp73GmMpFQpRM',
+            address: 'vaBdTQnKWstzbP9rrMCvPP4rxqLU3PDvKHM',
             amount: 200,
             unit: 'boson'
           },
@@ -375,10 +375,10 @@ describe('Intergallactic.Transaction', function () {
     }];
 
     this.timeout(5000);
-    setTimeout(function () { glOrWd.runTest(test, done); }, 5000);
+    setTimeout(function () { glOrWd.runTest(test, done); }, 2000);
   });
 
-  it.skip('"permission", should do permission transaction', function (done) {
+  it('"permission", should do permission transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
@@ -411,7 +411,7 @@ describe('Intergallactic.Transaction', function () {
             unit: 'boson'
           },
           to: {
-            address: 'acUGqVmMzbD6SNkbTevqjGhfnXwckAZL9Lm',
+            address: 'acG9u2dcdu1kZoSEyxuGU7aWv3sHA8KNebo',
             amount: 0,
             unit: 'boson'
           },
@@ -425,10 +425,10 @@ describe('Intergallactic.Transaction', function () {
     }];
 
     this.timeout(5000);
-    setTimeout(function () { glOrWd.runTest(test, done); }, 3000);
+    setTimeout(function () { glOrWd.runTest(test, done); }, 2000);
   });
 
-  it('"broadcast", should broadcast the transaction', function (done) {
+  it.skip('"broadcast", should broadcast the transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
@@ -471,7 +471,7 @@ describe('Intergallactic.Transaction', function () {
     setTimeout(function () { glOrWd.runTest(test, done) }, 5000);
   });
 
-  it('"signNBroadcast", should broadcast the transaction', function (done) {
+  it.skip('"signNBroadcast", should broadcast the transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });


### PR DESCRIPTION
This includes update for signing transaction. Previously signing transaction doesn't require hashing the message, however, the current process emphasize the keccak hash of the message that need to be signed or else the transaction would be rejected by the core blockchain