### PR TITLE
update transaction - building txn, make unit field as an option

### DIFF
--- a/lib/config/constant.js
+++ b/lib/config/constant.js
@@ -31,6 +31,7 @@ module.exports = {
       }
     },
     transaction: {
+      defaultUnit: 'boson',
       method: {
         broadcastTxn: 'gallactic.broadcastTx'
       }

--- a/lib/intergallactic/transaction.js
+++ b/lib/intergallactic/transaction.js
@@ -25,15 +25,13 @@ const config = require('../config/constant'),
  *   from: [{
  *     address: testAcc.address,
  *     amount: 10,
- *     unit: 'boson'
  *   }],
  *   to: [{
  *     address: 'acWmVcNrHzxBF8L25vdiKLsz664ZGkYmPRj',
  *     amount: 10
- *     unit: 'boson'
  *   }]
  * };
- * const opt = { txnType: 1 // required }
+ * const opt = { txnType: 1 // required, unit: 'boson' // default if not specified }
  * const newTxn = new igc.Transaction(txn, opt);
  * newTxn.signNBroadcast(privKey)
  *  .then(res => res contains transaction info)
@@ -48,6 +46,7 @@ class Transaction {
     this.utils = this.igc.utils;
     this._txn = data;
     this.txnType = getTxnSign(opt.type);
+    this.txnUnit = opt.unit || config.gallactic.transaction.defaultUnit;
     this.chainId = opt.chainId;
     this.sequence = opt.sequence;
   }
@@ -62,8 +61,8 @@ class Transaction {
       throw new Error('Chain id or sequence is not defined. Synchronous sign require chainId and sequence as parameter upon instantiate')
     }
 
-    this.txn = buildTxnByType(this._txn, this.txnType);
-    // Set Transaction sequence by transation type
+    this.txn = buildTxnByType(this._txn, this.txnType, { unit: this.txnUnit });
+    // Set Transaction sequence by transaction type
     setTxnSequence(this.txn, this.txnType, this.sequence);
 
     return signByPrivKey(privKey, this.txn, this.txnType, this.chainId);
@@ -110,7 +109,7 @@ class Transaction {
         throw new Error('Unable to retrieve sequence, please try again later');
       }
 
-      this.txn = buildTxnByType(this._txn, this.txnType);
+      this.txn = buildTxnByType(this._txn, this.txnType, { unit: this.txnUnit });
       setTxnSequence(this.txn, this.txnType, this.sequence);
       return;
     };
@@ -281,7 +280,7 @@ function signByPrivKey (privKey, txn, txnType, chainId) {
   );
 }
 
-function buildTxnByType (tx, txnType) {
+function buildTxnByType (tx, txnType, option) {
   let txn = {};
   if (txnType === SEND_TXN_TYPE) {
     txn = {
@@ -324,7 +323,7 @@ function buildTxnByType (tx, txnType) {
 
   return txn;
 
-  function setTxnFrom (from = {}) {
+  function setTxnFrom (from = {}, unit = option.unit) {
     if (!from.address) {
       throw new Error('Cant build transaction. from.address contains invalid address');
     }
@@ -334,18 +333,18 @@ function buildTxnByType (tx, txnType) {
 
     const newFrom = {
       address: from.address,
-      amount: conversion.toBoson(from.amount, from.unit).toNumber()
+      amount: conversion.toBoson(from.amount, unit).toNumber()
     }
     return newFrom;
   }
 
-  function setTxnTo (to = {}) {
+  function setTxnTo (to = {}, unit = option.unit) {
     if (typeof to.amount === 'undefined' || typeof to.amount === 'null') {
       throw new Error('Cant build transaction. to.amount contains invalid value')
     }
     const newTo = {
       address: to.address,
-      amount: conversion.toBoson(to.amount, to.unit).toNumber()
+      amount: conversion.toBoson(to.amount, unit).toNumber()
     };
     return newTo;
   }
@@ -385,6 +384,11 @@ function getTxnSign (txnType) {
   else throw new Error('Unable to get Transaction sign of transaction type ' + txnType);
 }
 
+/**
+ * Helper function to get transaction "from" key name based on txn type
+ * @param {Number} txnType A transaction type number (1 - SEND_TXN, 2 - CALL_TXN)
+ * @returns {String} A string of key name of "from" field
+ */
 function getTxnFromKey (txnType) {
   switch (txnType) {
     case SEND_TXN_TYPE: return config.transactionFromKey.send;
@@ -396,12 +400,20 @@ function getTxnFromKey (txnType) {
   }
 }
 
+/**
+ * Helper function to help validate signatories object for broadcasting purpose
+ * @param   {Array}  signatories  array of signatory object that contains pub key and signature
+ */
 function validateSignatories (signatories) {
   if (!Array.isArray(signatories) || signatories.length === 0) {
     throw new Error('signatories with valid signature and pubKey is required for sending transaction')
   }
 }
 
+/**
+ * Helper function to help validate transaction type upon instanciate and function call
+ * @param   {Array}  signatories  array of signatory object that contains pub key and signature
+ */
 function validateTxnType (givenTxnType, expectedTxnType) {
   if (givenTxnType !== expectedTxnType) {
     throw new Error('Transaction was instantiated not for its purpose. Unable to proceed');

--- a/test/intergallactic/transaction.test.js
+++ b/test/intergallactic/transaction.test.js
@@ -70,8 +70,7 @@ describe('Intergallactic.Transaction', function () {
         txn: {
           from: [{
             address: testAcc.address,
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           }],
           to: [{
             address: 'acQUFGxsXVPSd6vbAceSkURnWhYhApE9VRe',
@@ -192,7 +191,7 @@ describe('Intergallactic.Transaction', function () {
   it('"send", should send the transaction', function (done) {
     const test = {
       function: (data) => {
-        const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
+        const newTxn = new igc.Transaction(data.txn, data.option);
         return newTxn.sign(data.privKey)
           .then(signature => {
             const signatories = [{
@@ -213,17 +212,18 @@ describe('Intergallactic.Transaction', function () {
       input: {
         privKey: testAcc.privKey,
         pubKey: testAcc.pubKey,
-        txnType: 1,
+        option: {
+          type: 1,
+          unit: 'boson'
+        },
         txn: {
           from: [{
             address: testAcc.address,
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           }],
           to: [{
             address: 'acWmVcNrHzxBF8L25vdiKLsz664ZGkYmPRj',
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           }]
         }
       }
@@ -307,13 +307,11 @@ describe('Intergallactic.Transaction', function () {
         txn: {
           from: {
             address: testAcc.address,
-            amount: 200,
-            unit: 'boson'
+            amount: 200
           },
           to: {
             address: 'vaBdTQnKWstzbP9rrMCvPP4rxqLU3PDvKHM',
-            amount: 100,
-            unit: 'boson'
+            amount: 100
           },
           publicKey: 'pjDvQc1rF8HhCAK8L8zu3SJQcKtCMroo1rmRWf8o8m111DexqzX'
         }
@@ -359,13 +357,11 @@ describe('Intergallactic.Transaction', function () {
           from: {
             // address: testAcc.address
             address: 'vaBdTQnKWstzbP9rrMCvPP4rxqLU3PDvKHM',
-            amount: 200,
-            unit: 'boson'
+            amount: 200
           },
           to: {
             address: testAcc.address,
-            amount: 100,
-            unit: 'boson'
+            amount: 100
           }
         }
       },
@@ -407,13 +403,11 @@ describe('Intergallactic.Transaction', function () {
         txn: {
           from: {
             address: testAcc.address,
-            amount: 100,
-            unit: 'boson'
+            amount: 100
           },
           to: {
             address: 'acG9u2dcdu1kZoSEyxuGU7aWv3sHA8KNebo',
-            amount: 0,
-            unit: 'boson'
+            amount: 0
           },
           permissions: '0x4',
           set: true
@@ -428,7 +422,7 @@ describe('Intergallactic.Transaction', function () {
     setTimeout(function () { glOrWd.runTest(test, done); }, 2000);
   });
 
-  it.skip('"broadcast", should broadcast the transaction', function (done) {
+  it('"broadcast", should broadcast the transaction', function (done) {
     const test = {
       function: (data) => {
         const newTxn = new igc.Transaction(data.txn, { type: data.txnType });
@@ -455,13 +449,11 @@ describe('Intergallactic.Transaction', function () {
         txn: {
           from: [{
             address: testAcc.address,
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           }],
           to: [{
             address: 'acWmVcNrHzxBF8L25vdiKLsz664ZGkYmPRj',
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           }]
         }
       }
@@ -494,13 +486,11 @@ describe('Intergallactic.Transaction', function () {
         txn: {
           from: {
             address: testAcc.address,
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           },
           to: {
             address: '',
-            amount: 10,
-            unit: 'boson'
+            amount: 10
           },
           gasLimit: 1,
           data: '010203' // currently require an input of byte array


### PR DESCRIPTION
These changes, allow developers to just specify "unit" value as an option instead defining it under "from" or "to" field. By default, "unit" value set as "boson". This will resolve confusion for issue referenced below

close #9 